### PR TITLE
Add example of TS-code not working in TSX file

### DIFF
--- a/packages/components/src/CompTwo/CompTwo.tsx
+++ b/packages/components/src/CompTwo/CompTwo.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import './CompTwo.css';
 
+enum Test {
+	a,
+	b
+}
+
 const CompTwo = () => (
 	<div className="Comp">
 		<h3>


### PR DESCRIPTION
When starting `app-one`:

```
.../react-workspaces-playground/packages/components/src/CompTwo/CompTwo.tsx
  Line 4:1:  Parsing error: Unexpected reserved word 'enum'

  2 | import './CompTwo.css';
  3 | 
> 4 | enum Test {
    | ^
  5 |   a,
  6 |   b
  7 | }
```

Which parser is being used? The code works fine with TSC:

```
react-workspaces-playground git:(master) cd packages/components; yarn build
yarn run v1.19.1
$ tsc -p tsconfig.json
✨  Done in 1.13s.
```

Adding the enum to `packages/app-one/src/App.tsx` works fine. The transpiler seems to be confused when dealing with TypeScript in shared modules/packages.

Ideas? @priley86 @cmsd2